### PR TITLE
updated simplesmtp to ~0.3.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "linger": "0.0.3",
-    "simplesmtp": "~0.3.24",
+    "simplesmtp": "~0.3.35",
     "nomnom": "~1.6.2",
     "cli-prompt": "~0.3.2"
   }


### PR DESCRIPTION
to avoid an exception in mailwurst, see http://stackoverflow.com/questions/28579806/heroku-issue-with-nodemailer

tests are green. Kind of.
